### PR TITLE
AffineCopyOptions.alignment added

### DIFF
--- a/mlir/include/mlir/Transforms/LoopUtils.h
+++ b/mlir/include/mlir/Transforms/LoopUtils.h
@@ -178,8 +178,8 @@ struct AffineCopyOptions {
   // generate new indices, effectively enforcing a new layout; row major
   // layout is unsed if left unspecified.
   AffineMap fastBufferLayout;
-  // optional alignment argument, specifies the alignment explicitly
-  // for the `alloc` of the copy buffer
+  // This optional argument specifies the data alignment for the `alloc`
+  // instruction of the copy buffer.
   uint64_t alignment = 0;
 };
 

--- a/mlir/include/mlir/Transforms/LoopUtils.h
+++ b/mlir/include/mlir/Transforms/LoopUtils.h
@@ -178,9 +178,9 @@ struct AffineCopyOptions {
   // generate new indices, effectively enforcing a new layout; row major
   // layout is unsed if left unspecified.
   AffineMap fastBufferLayout;
-  //optional alignment argument, specifies the alignment explicitly
-  //for the `alloc` of the copy buffer 
-  uint64_t alignment=0;
+  // optional alignment argument, specifies the alignment explicitly
+  // for the `alloc` of the copy buffer
+  uint64_t alignment = 0;
 };
 
 /// Performs explicit copying for the contiguous sequence of operations in the

--- a/mlir/include/mlir/Transforms/LoopUtils.h
+++ b/mlir/include/mlir/Transforms/LoopUtils.h
@@ -178,6 +178,9 @@ struct AffineCopyOptions {
   // generate new indices, effectively enforcing a new layout; row major
   // layout is unsed if left unspecified.
   AffineMap fastBufferLayout;
+  //optional alignment argument, specifies the alignment explicitly
+  //for the `alloc` of the copy buffer 
+  uint64_t alignment=0;
 };
 
 /// Performs explicit copying for the contiguous sequence of operations in the

--- a/mlir/lib/Analysis/AffineStructures.cpp
+++ b/mlir/lib/Analysis/AffineStructures.cpp
@@ -684,7 +684,7 @@ LogicalResult FlatAffineConstraints::addAffineForOpDomain(AffineForOp forOp) {
   int64_t step = forOp.getStep();
   if (step != 1) {
     if (!forOp.hasConstantLowerBound())
-      forOp.emitWarning("domain conservatively approximated");
+      LLVM_DEBUG(forOp.emitWarning("domain conservatively approximated"));
     else {
       // Add constraints for the stride.
       // (iv - lb) % step = 0 can be written as:

--- a/mlir/lib/Transforms/Utils/LoopUtils.cpp
+++ b/mlir/lib/Transforms/Utils/LoopUtils.cpp
@@ -2099,7 +2099,15 @@ static LogicalResult generateCopy(
 
     // Create the fast memory space buffer just before the 'affine.for'
     // operation.
-    fastMemRef = prologue.create<AllocOp>(loc, fastMemRefType).getResult();
+    AllocOp allocOp = prologue.create<AllocOp>(loc, fastMemRefType);
+    if(copyOptions.alignment){
+        allocOp.setAttr(AllocOp::getAlignmentAttrName(),
+                prologue.getI64IntegerAttr(copyOptions.alignment));
+    }
+    fastMemRef = allocOp.getResult();
+
+
+
     // Record it.
     fastBufferMap[memref] = fastMemRef;
     // fastMemRefType is a constant shaped memref.

--- a/mlir/lib/Transforms/Utils/LoopUtils.cpp
+++ b/mlir/lib/Transforms/Utils/LoopUtils.cpp
@@ -2100,10 +2100,9 @@ static LogicalResult generateCopy(
     // Create the fast memory space buffer just before the 'affine.for'
     // operation.
     AllocOp allocOp = prologue.create<AllocOp>(loc, fastMemRefType);
-    if (copyOptions.alignment) {
+    if (copyOptions.alignment)
       allocOp.setAttr(AllocOp::getAlignmentAttrName(),
                       prologue.getI64IntegerAttr(copyOptions.alignment));
-    }
     fastMemRef = allocOp.getResult();
 
     // Record it.

--- a/mlir/lib/Transforms/Utils/LoopUtils.cpp
+++ b/mlir/lib/Transforms/Utils/LoopUtils.cpp
@@ -2100,13 +2100,11 @@ static LogicalResult generateCopy(
     // Create the fast memory space buffer just before the 'affine.for'
     // operation.
     AllocOp allocOp = prologue.create<AllocOp>(loc, fastMemRefType);
-    if(copyOptions.alignment){
-        allocOp.setAttr(AllocOp::getAlignmentAttrName(),
-                prologue.getI64IntegerAttr(copyOptions.alignment));
+    if (copyOptions.alignment) {
+      allocOp.setAttr(AllocOp::getAlignmentAttrName(),
+                      prologue.getI64IntegerAttr(copyOptions.alignment));
     }
     fastMemRef = allocOp.getResult();
-
-
 
     // Record it.
     fastBufferMap[memref] = fastMemRef;

--- a/mlir/test/Dialect/Affine/affine-data-copy-align.mlir
+++ b/mlir/test/Dialect/Affine/affine-data-copy-align.mlir
@@ -1,4 +1,4 @@
-/// Checks for the optional buffer alignment attribute in the alloc instruction
+/// Checks for the buffer alignment attribute in the alloc instruction.
 // RUN: mlir-opt %s -test-affine-data-copy="alloc-alignment" -split-input-file | FileCheck %s
 // CHECK-LABEL: func @simple_gemm
 // CHECK: %{{[0-9]+}} = alloc() {alignment = {{[0-9]+}} : i64} : memref<{{[0-9]+}}x{{[0-9]+}}xf32>

--- a/mlir/test/Dialect/Affine/affine-data-copy-align.mlir
+++ b/mlir/test/Dialect/Affine/affine-data-copy-align.mlir
@@ -1,0 +1,20 @@
+/// Checks for the optional buffer alignment attribute in the alloc instruction
+// RUN: mlir-opt %s -test-affine-data-copy="alloc-alignment" -split-input-file | FileCheck %s
+// CHECK-LABEL: func @simple_gemm
+// CHECK: %{{[0-9]+}} = alloc() {alignment = {{[0-9]+}} : i64} : memref<{{[0-9]+}}x{{[0-9]+}}xf32>
+func @simple_gemm(%A: memref<2048x2048xf32>, %B: memref<2048x2048xf32>, %C: memref<2048x2048xf32>) {
+  affine.for %arg3 = 0 to 2048 {
+    affine.for %arg4 = 0 to 2048 {
+      affine.for %arg5 = 0 to 2048 {
+        %a = affine.load %A[%arg3, %arg5] : memref<2048x2048xf32>
+        %b = affine.load %B[%arg5, %arg4] : memref<2048x2048xf32>
+        %ci = affine.load %C[%arg3, %arg4] : memref<2048x2048xf32>
+        %p = mulf %a, %b : f32
+        %co = addf %ci, %p : f32
+        affine.store %co, %C[%arg3, %arg4] : memref<2048x2048xf32>
+      }
+    }
+  }
+ return
+}
+

--- a/mlir/test/lib/Dialect/Affine/TestAffineDataCopy.cpp
+++ b/mlir/test/lib/Dialect/Affine/TestAffineDataCopy.cpp
@@ -47,7 +47,6 @@ private:
       *this, "alloc-alignment",
       llvm::cl::desc("Test alignment attribute of alloc instruction"),
       llvm::cl::init(false)};
-
 };
 
 } // end anonymous namespace
@@ -57,7 +56,7 @@ void TestAffineDataCopy::runOnFunction() {
   std::vector<SmallVector<AffineForOp, 2>> depthToLoops;
   gatherLoops(getFunction(), depthToLoops);
   assert(depthToLoops.size() && "Loop nest not found");
-	
+
   // Only support tests with a single loop nest and a single innermost loop
   // for now.
   unsigned innermostLoopIdx = depthToLoops.size() - 1;
@@ -67,7 +66,8 @@ void TestAffineDataCopy::runOnFunction() {
   auto loopNest = depthToLoops[0][0];
   auto innermostLoop = depthToLoops[innermostLoopIdx][0];
   AffineLoadOp load;
-  if (clMemRefFilter || clTestGenerateCopyForMemRegion || clTestAllocAlignment) {
+  if (clMemRefFilter || clTestGenerateCopyForMemRegion ||
+      clTestAllocAlignment) {
     // Gather MemRef filter. For simplicity, we use the first loaded memref
     // found in the innermost loop.
     for (auto &op : *innermostLoop.getBody()) {
@@ -83,8 +83,7 @@ void TestAffineDataCopy::runOnFunction() {
                                    /*fastMemorySpace=*/0,
                                    /*tagMemorySpace=*/0,
                                    /*fastMemCapacityBytes=*/32 * 1024 * 1024UL,
-                                   /*fastBufLayout*/{}
-  };
+                                   /*fastBufLayout*/ {}};
   DenseSet<Operation *> copyNests;
 
   if (clMemRefFilter) {
@@ -95,10 +94,9 @@ void TestAffineDataCopy::runOnFunction() {
     region.compute(load, /*loopDepth=*/0);
     generateCopyForMemRegion(region, loopNest, copyOptions, result);
   } else if (clTestAllocAlignment) {
-	copyOptions.alignment = 64;
+    copyOptions.alignment = 64;
     affineDataCopyGenerate(loopNest, copyOptions, load.getMemRef(), copyNests);
   }
-
 
   // Promote any single iteration loops in the copy nests and simplify
   // load/stores.

--- a/mlir/test/lib/Dialect/Affine/TestAffineDataCopy.cpp
+++ b/mlir/test/lib/Dialect/Affine/TestAffineDataCopy.cpp
@@ -83,7 +83,7 @@ void TestAffineDataCopy::runOnFunction() {
                                    /*fastMemorySpace=*/0,
                                    /*tagMemorySpace=*/0,
                                    /*fastMemCapacityBytes=*/32 * 1024 * 1024UL,
-                                   /*fastBufLayout*/ {}};
+                                   /*fastBufLayout*/{}};
   DenseSet<Operation *> copyNests;
 
   if (clMemRefFilter) {


### PR DESCRIPTION
`affineDataCopyGenerate` does not add alignment attribute to the newly declared copy buffers. Added a new `alignment` field to `AffineCopyOptions`. Please refer to the following example's data copy region in `func @matmul`.

```
#map0 = affine_map<(d0) -> (d0)>
#map1 = affine_map<(d0, d1) -> (d0, d1)>
#map2 = affine_map<(d0, d1, d2) -> (d1, -d0 + d2)>
#map3 = affine_map<(d0) -> (d0 + 1)>
#map4 = affine_map<() -> (0)>
#map5 = affine_map<() -> (2048)>
#map6 = affine_map<(d0) -> (d0, 0)>
#map7 = affine_map<() -> (128)>
module {
  func @matmul(%arg0: memref<2048x2048xf32>, %arg1: memref<2048x2048xf32>, %arg2: memref<2048x2048xf32>) {
    %c2048 = constant 2048 : index
    %c0 = constant 0 : index
    %0 = memref_shape_cast %arg2 : memref<2048x2048xf32> to memref<2048x128xvector<16xf32>>
    %1 = memref_shape_cast %arg1 : memref<2048x2048xf32> to memref<2048x128xvector<16xf32>>
    affine.for %arg3 = 0 to 128 {
      %2 = affine.apply #map0(%arg3)
      // In `alloc` below, alignment of original buffer is not honored. Leads to undefined behavior/runtime seg-faults.
      // Copy buffer is aligned with `copyOption.alignment` to generate,
      // %3 = alloc() {alignment = 64 : i64} : memref<2048x1xvector<16xf32>>
      %3 = alloc() : memref<2048x1xvector<16xf32>>
      affine.for %arg4 = 0 to 2048 {
        affine.for %arg5 = #map0(%arg3) to #map3(%arg3) {
          %4 = affine.load %1[%arg4, %arg5] : memref<2048x128xvector<16xf32>>
          affine.store %4, %3[%arg4, -%arg3 + %arg5] : memref<2048x1xvector<16xf32>>
        }
      }
      affine.for %arg4 = 0 to 2048 {
        affine.for %arg5 = 0 to 2048 {
          %4 = affine.load %arg0[%arg4, %arg5] : memref<2048x2048xf32>
          %5 = splat %4 : vector<16xf32>
          %6 = affine.load %3[%arg5, 0] : memref<2048x1xvector<16xf32>>
          %7 = affine.load %0[%arg4, %arg3] : memref<2048x128xvector<16xf32>>
          %8 = mulf %5, %6 : vector<16xf32>
          %9 = addf %7, %8 : vector<16xf32>
          affine.store %9, %0[%arg4, %arg3] : memref<2048x128xvector<16xf32>>
        }
      }
      dealloc %3 : memref<2048x1xvector<16xf32>>
    }
    return
  }
  func @main() {
    %cst = constant 1.000000e+00 : f32
    %cst_0 = constant 0.000000e+00 : f32
    %0 = alloc() {alignment = 64 : i64} : memref<2048x2048xf32>
    %1 = alloc() {alignment = 64 : i64} : memref<2048x2048xf32>
    %2 = alloc() {alignment = 64 : i64} : memref<2048x2048xf32>
    linalg.fill(%0, %cst) : memref<2048x2048xf32>, f32
    linalg.fill(%1, %cst) : memref<2048x2048xf32>, f32
    linalg.fill(%2, %cst_0) : memref<2048x2048xf32>, f32
    call @matmul(%0, %1, %2) : (memref<2048x2048xf32>, memref<2048x2048xf32>, memref<2048x2048xf32>) -> ()
    return
  }
}
```