### PR TITLE
Update dgemm-hop.mlir test case for linalg.fill

### DIFF
--- a/mlir/benchmark/README.md
+++ b/mlir/benchmark/README.md
@@ -1,4 +1,3 @@
-
 This information goes together with this article on high-performance code
 generation in MLIR:
 https://github.com/bondhugula/llvm-project/blob/hop/mlir/docs/HighPerfCodeGen.md
@@ -10,12 +9,12 @@ See the benchmark/ directory in mlir/.
 To execute the included benchmark:
 
 ```
-$ mlir-opt benchmark/dgemm-tiled-benchmark.mlir \
+$ bin/mlir-opt ../mlir/benchmark/dgemm-tiled-benchmark.mlir \
     -hopt='vect=true copy=true unroll=true scalrep=true' \
     -convert-linalg-to-loops -lower-affine -convert-scf-to-std \
     -convert-memref-to-llvm='use-aligned-alloc=1' -convert-std-to-llvm \
     -canonicalize \
-    | mlir-cpu-runner  -O3  -e main -time -reps=5 -entry-point-result=void \
+    | bin/mlir-cpu-runner  -O3  -e main -time -reps=5 -entry-point-result=void \
     -shared-libs=lib/libmlir_runner_utils.so \
     -shared-libs=lib/libmlir_c_runner_utils.so > /dev/null
 ```

--- a/mlir/benchmark/dgemm-hop.mlir
+++ b/mlir/benchmark/dgemm-hop.mlir
@@ -8,14 +8,14 @@ func @main() {
 
   %cf1 = constant 1.00000e+00 : f64
 
-  linalg.fill(%A, %cf1) : memref<2088x2048xf64>, f64
-  linalg.fill(%B, %cf1) : memref<2048x2048xf64>, f64
+  linalg.fill(%cf1, %A) : f64, memref<2088x2048xf64>
+  linalg.fill(%cf1, %B) : f64, memref<2048x2048xf64>
 
   %reps = constant 5 : index
 
   %t_start = call @rtclock() : () -> (f64)
   affine.for %ti = 0 to %reps {
-    linalg.fill(%C, %cf1) : memref<2088x2048xf64>, f64
+    linalg.fill(%cf1, %C) : f64, memref<2088x2048xf64>
     call @matmul_hop(%A, %B, %C) : (memref<2088x2048xf64>, memref<2048x2048xf64>, memref<2088x2048xf64>) -> ()
   }
   %t_end = call @rtclock() : () -> (f64)


### PR DESCRIPTION
Update dgemm-hop.mlir test case for linalg.fill. Update README.md for
consistent relative paths.